### PR TITLE
Return indent issue

### DIFF
--- a/hybdrt/fileload.py
+++ b/hybdrt/fileload.py
@@ -196,7 +196,7 @@ def read_chrono(file, source=None):
     else:
         raise ValueError(f'read_chrono is not implemented for source {source}')
 
-        return data
+    return data
 
 
 def concatenate_chrono_data(chrono_data_list, eis_data_list=None, trim_index=None, trim_time=None,


### PR DESCRIPTION
I think the return is indented too far on line 199. I was getting noneType when running the script as it stands.